### PR TITLE
1.08

### DIFF
--- a/ChatTopBar.user.js
+++ b/ChatTopBar.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Top bar in chat.
 // @namespace    https://stackexchange.com/users/305991/jason-c
-// @version      1.08-dev4
+// @version      1.08-dev5
 // @description  Add a fully functional top bar to chat windows.
 // @author       Jason C
 // @match        *://chat.meta.stackexchange.com/rooms/*
@@ -409,6 +409,20 @@
             background: '#0f0',
             color: 'black'
         }).data('updated', newVersion);
+
+        // Blinky blinky.
+        let i = window.setInterval(function () {
+            let link = $('#ctb-settings-link');
+            if (link.data('updated')) {
+                if (link.data('flasher'))
+                    link.css('background', '#0f0');
+                else
+                    link.css('background', '#ff0');
+                link.data('flasher', link.data('flasher') ? false : true);
+            } else {
+                window.clearInterval(i);
+            }
+        }, 500);
 
     }
 

--- a/ChatTopBar.user.js
+++ b/ChatTopBar.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Top bar in chat.
 // @namespace    https://stackexchange.com/users/305991/jason-c
-// @version      1.08-dev6
+// @version      1.08
 // @description  Add a fully functional top bar to chat windows.
 // @author       Jason C
 // @match        *://chat.meta.stackexchange.com/rooms/*

--- a/ChatTopBar.user.js
+++ b/ChatTopBar.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Top bar in chat.
 // @namespace    https://stackexchange.com/users/305991/jason-c
-// @version      1.08
+// @version      1.08-dev3
 // @description  Add a fully functional top bar to chat windows.
 // @author       Jason C
 // @match        *://chat.meta.stackexchange.com/rooms/*
@@ -299,9 +299,9 @@
                 `<div id="ctb-settings-dialog" title="Settings${title}">` +
                 '<label><input type="checkbox" name="themed" onchange="ChatTopBar.setThemed(this.checked)"><span>Use chat room themes</span></label>' +
                 '<label><input type="checkbox" name="widen" onchange="ChatTopBar.setWiden(this.checked)"><span>Wide layout</span></label>' +
-                '<label><input type="checkbox" name="quiet" onchange="ChatTopBar.setQuiet(this.checked)"><span>Suppress console output</span></label>' +
                 '<label><input type="checkbox" name="switch" onchange="ChatTopBar.setShowSwitcher(this.checked)"><span>Show chat servers in SE dropdown</span></label>' +
                 '<label><input type="checkbox" name="rejoin" onchange="ChatTopBar.setRejoinOnSwitch(this.checked)"><span>Rejoin favorites on switch</span></label>' +
+                '<label><input type="checkbox" name="quiet" onchange="ChatTopBar.setQuiet(this.checked)"><span>Suppress console output</span></label>' +
                 '<hr><label class="ctb-fixheight"><span>Brightness (this room only):</span></label>' +
                 '<div class="ctb-fixheight"><div style="flex-grow:1" id="ctb-settings-brightness"></div></div><hr>' +
                 `<div class="ctb-fixheight"><a href="${URL_UPDATES}">Updates</a>&nbsp;|&nbsp;<a href="${URL_MORE}">More Scripts</a></div>` +

--- a/ChatTopBar.user.js
+++ b/ChatTopBar.user.js
@@ -441,8 +441,9 @@
 
         if ($('#ctb-changes-dialog').length === 0) {
             let title = (typeof GM_info === 'undefined' ? '' : ` (${GM_info.script.version})`);
+            let devmsg = title.includes('dev') ? ' <b>You\'re using a development version, you won\'t receive release updates until you reinstall from the StackApps page again.</b>' : '';
             $('body').append(
-                `<div id="ctb-changes-dialog" title="Chat Top Bar Change Log${title}"><div class="ctb-important">For details see <a href="${URL_UPDATES}">the StackApps page</a>!</div><ul id="ctb-changes-list">` +
+                `<div id="ctb-changes-dialog" title="Chat Top Bar Change Log${title}"><div class="ctb-important">For details see <a href="${URL_UPDATES}">the StackApps page</a>!${devmsg}</div><ul id="ctb-changes-list">` +
                 '<li class="ctb-version-item">1.08<li><ul>' +
                 '<li>• Chat server links placed in SE dropdown (click name to open in new tab, "switch" to open in current tab).' +
                 '<li>• Clicking "switch" on chat server link automatically rejoins favorite rooms (can be disabled in settings).' +

--- a/ChatTopBar.user.js
+++ b/ChatTopBar.user.js
@@ -312,8 +312,9 @@
                 '<label><input type="checkbox" name="quiet" onchange="ChatTopBar.setQuiet(this.checked)"><span>Suppress console output</span></label>' +
                 '<hr><label class="ctb-fixheight"><span>Brightness (this room only):</span></label>' +
                 '<div class="ctb-fixheight"><div style="flex-grow:1" id="ctb-settings-brightness"></div></div><hr>' +
-                `<div class="ctb-fixheight"><a href="${URL_UPDATES}">Updates</a>&nbsp;|&nbsp;<a href="${URL_MORE}">More Scripts</a></div>` +
+                `<div class="ctb-fixheight" style="white-space:nowrap"><a href="${URL_UPDATES}">Updates</a>&nbsp;|&nbsp;<a href="${URL_MORE}">More Scripts</a>&nbsp;|&nbsp;<a href="#" id="ctb-show-log">Change Log</a></div>` +
                 '</div>');
+            $('#ctb-show-log').click(() => (showChangeLog(), showSettings(), false));
             let elem = $('#ctb-settings-dialog');
             elem.find('hr').css({'border':'0', 'border-bottom':$('#present-users').css('border-bottom')});
             elem.find('label, .ctb-fixheight').css({'display':'flex', 'align-items':'center'});


### PR DESCRIPTION
1.08
- Chat server links placed in SE dropdown (click name to open in new tab, "switch" to open in current tab).
- Clicking "switch" on chat server link automatically rejoins favorite rooms (can be disabled in settings).
- Brightness setting is now associated with the current room's theme rather than the room itself (so it applies to all rooms with the same theme). Apologies for any reset settings (it does make a good attempt to copy them, though).
- Change log now displayed after update (when flashin "topbar" link clicked).
- ChatTopBar.showChangeLog() will always show the change log, too.
- ChatTopBar functions for additional settings added.
- Don't load jQuery UI if it's already loaded.